### PR TITLE
[Refactor] Pinecone DB 클래스 및 적재 파이프라인 개선

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -1,20 +1,29 @@
 from langchain_openai import OpenAIEmbeddings
-from pinecone import Pinecone
+from pinecone import Pinecone, ServerlessSpec
+from dotenv import load_dotenv
 from pathlib import Path
-from dotenv import load_dotenv 
 import os
-
-
 load_dotenv()
-PINECONE_API_KEY = os.getenv("PINECONE_API_KEY")
 
+# API 키 로드
+PINECONE_API_KEY = os.getenv("PINECONE_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+
+# 데이터 경로 설정
 DATA_PATH = Path(__file__).resolve().parent.parent / 'datas'
-RAW_FILE_PATH = os.path.join(DATA_PATH, 'flower_data.json')
-NEW_FILE_PATH = os.path.join(DATA_PATH, 'new_data.json')
-REC_FILE_PATH = os.path.join(DATA_PATH, 'flower_preprocessed_data.json')
-QNA_FILE_PATH = os.path.join(DATA_PATH, 'post_preprocessed_data.json')
+
+# 원본 데이터
+RAW_FILE_PATH = DATA_PATH / 'flower_data.json'
+NEW_FILE_PATH = DATA_PATH / 'new_data.json'
+
+# 벡터 DB 적재 데이터
+REC_FILE_PATH = DATA_PATH / 'flower_preprocessed_data.json'
+QNA_FILE_PATH = DATA_PATH / 'post_preprocessed_data.json'
+
+# 인덱스 이름 설정
 REC_INDEX_NAME = "plant-recommend"
 QNA_INDEX_NAME = "plant-qna"
 
+# 파인콘DB, 임베딩 모델
 pc = Pinecone(api_key=PINECONE_API_KEY)
 embeddings = OpenAIEmbeddings(model="text-embedding-3-small")

--- a/modules/db.py
+++ b/modules/db.py
@@ -1,103 +1,165 @@
-from langchain_core.documents import Document
-from pinecone import ServerlessSpec
-from config import *
+from langchain_openai import OpenAIEmbeddings
+from pinecone import Pinecone, ServerlessSpec
+from datetime import datetime 
+from config import PINECONE_API_KEY, REC_INDEX_NAME, QNA_INDEX_NAME, REC_FILE_PATH, QNA_FILE_PATH, pc, embeddings
 import pandas as pd
+import argparse
 import json
 
 
-def load_data(file_path):
-    with open(file_path, "r", encoding="utf-8") as f:
-        raw_data = json.load(f)
+class PineconeManager:
+    def __init__(self):
+        # self.pc = Pinecone(api_key=PINECONE_API_KEY)
+        # self.embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+        self.pc = pc 
+        self.embeddings = embeddings
+        self.dimension = 1536
+        self.upsert_dt = datetime.now().strftime("%y%m%d")
+        self.INDEX = None
 
-    return raw_data
 
-
-def create_db(index_name):   
-    if index_name not in [idx["name"] for idx in pc.list_indexes()]:
-        pc.create_index(
-            name=index_name,
-            dimension=1536,
-            metric='cosine',
-            spec=ServerlessSpec(cloud="aws", region="us-east-1")
-        )
-
-    return pc.Index(index_name)
-
+    def load_index(self, index_name):   
+        if index_name not in [idx["name"] for idx in self.pc.list_indexes()]:
+            self.pc.create_index(
+                name=index_name,
+                dimension=self.dimension,
+                metric='cosine',
+                spec=ServerlessSpec(cloud="aws", region="us-east-1")
+            )
+        self.INDEX = self.pc.Index(index_name)
+        print(f"[INFO] {index_name} | 로드 완료")
+        return self.INDEX
     
-def _create_text_for_embedding(row):
-    air_cond_text = '공기정화식물이다.' if row['isAirCond'] else ''
-    toxic_dog_text = '' if row['isToxicToDog'] else '강아지에게 안전하다.'
-    toxic_cat_text = '' if row['isToxicToCat'] else '고양이에게 안전하다.'
-    colors = " ".join(row['colors'])
 
-    return (
-        f"{row['flowLang']}, "
-        f"{row['fContent']}, "
-        f"물주기: {row['watering_frequency']}, "
-        f"난이도 {row['difficulty']}, "
-        f"{row['interior']}, "
-        f"{row['style']}, "
-        f"{row['fUse']}, "
-        f"{row['fGrow']}, "
-        f"{row['fType']}. "
-        f"{air_cond_text} "
-        f"{toxic_dog_text} "
-        f"{toxic_cat_text} "
-        f"{colors} "
-    ).strip()
-
-
-def insert_rec_index(raw_data):
-    df = pd.DataFrame(raw_data)
-    df['text_to_embed'] = df.apply(_create_text_for_embedding, axis=1)
-    texts = df['text_to_embed'].tolist()
-    vector = embeddings.embed_documents(texts)
-
-    for i, row in df.iterrows():
-        metadatas = row.drop(['fSctNm', 'fEngNm', 'fileName1', 'fileName2', 'fileName3', 'publishOrg', 'colors', 'text_to_embed']).to_dict()
-        metadatas["text"] = row["text_to_embed"]
-
-        rec_index.upsert([
-            (
-                str(row['dataNo']),
-                vector[i],
-                metadatas
-            )
-        ])
-
-
-def insert_qna_index(raw_data):
-    documents = []
-    for item in raw_data:
-        text = f"Q: {item['question']}\nA: {item['answer']}"
-        documents.append(
-            Document(page_content=text, metadata=item.get("metadata", {}))
+    def read_index(self, query, namespace=""):        
+        query_embeddings = self.embeddings.embed_query(query)        
+        query_response = \
+        self.INDEX.query(
+            namespace = namespace,     # 인덱스 내 검색할 네임스페이스
+            top_k = 3,                 # 결과 반환 갯수
+            include_values=False,      # 벡터 임베딩 반환 여부
+            include_metadata=True,     # 메타 데이터 반환 여부
+            vector=query_embeddings    # 검색할 벡터 임베딩
         )
+        return query_response
+        
 
-    for idx, docs in enumerate(documents):
-        id_ = "groro" + "_" + str(idx + 1) + "_" + str(docs.metadata['post_id'])
-        vector = embeddings.embed_query(docs.page_content)
+    def update_index(self, id, query, metadata={}, namespace=""):
+        query_embeddings = self.embeddings.embed_query(query)  
+        update_response = \
+        self.INDEX.update(
+            id=id,                     # 업데이트 할 기존 문서 ID
+            values=query_embeddings,   # NEW 벡터임베딩
+            set_metadata=metadata,     # NEW 메타데이터
+            namespace=namespace
+        )
+        return update_response
 
-        qna_index.upsert([
-            (
-                id_, 
-                vector, 
-                {'text': docs.page_content, **docs.metadata}
-            )
-        ])
+
+    def delete_index(self, id_list, namespace=""):
+        delete_response = \
+        self.INDEX.delete(
+            ids=id_list,               # 삭제할 문서ID (type: 리스트)
+            namespace=namespace        # 인덱스 내 검색할 네임스페이스
+        )
+        return delete_response
+
+
+class PineconeRagIngestor(PineconeManager):
+    def __init__(self):
+        super().__init__()
+
+    # 적재할 데이터 불러오기
+    def load_data(self, file_path):
+        with open(file_path, "r", encoding="utf-8") as f:
+            raw_data = json.load(f)        
+        self.df = pd.DataFrame(raw_data[:7])  
+        print(f"[INFO] {len(self.df)}건 데이터 로드 완료")
+        return self.df
+    
+    # 임베딩 텍스트 전처리 
+    def _create_text_for_embedding(self, index_name, row):
+        if REC_INDEX_NAME == index_name:
+            air_cond_text = '공기정화식물이다.' if row['isAirCond'] else ''
+            toxic_dog_text = '' if row['isToxicToDog'] else '강아지에게 안전하다.'
+            toxic_cat_text = '' if row['isToxicToCat'] else '고양이에게 안전하다.'
+            colors = " ".join(row['colors'])           
+            return (
+                f"{row['flowLang']}, "
+                f"{row['fContent']}, "
+                f"물주기: {row['watering_frequency']}, "
+                f"난이도 {row['difficulty']}, "
+                f"{row['interior']}, "
+                f"{row['style']}, "
+                f"{row['fUse']}, "
+                f"{row['fGrow']}, "
+                f"{row['fType']}. "
+                f"{air_cond_text} "
+                f"{toxic_dog_text} "
+                f"{toxic_cat_text} "
+                f"{colors} "
+            ).strip()
+
+        elif QNA_INDEX_NAME == index_name:            
+            return f"Question: {row['question']}\nAnswer: {row['answer']}"
+        
+    # 데이터 적재
+    def upsert_index(self, index_name):
+
+        # 임베딩 텍스트
+        self.df['text_to_embed'] = self.df.apply(lambda x: self._create_text_for_embedding(index_name, x), axis=1)
+        print(f"[INFO] {index_name} 전처리 완료")
+
+        # 문서ID, 벡터임베딩, 메타데이터
+        if index_name == REC_INDEX_NAME:
+            id_ = self.df['dataNo']
+            vector_ = self.embeddings.embed_documents(self.df['text_to_embed'].tolist())
+            metadata_ = self.df.rename(columns={'text_to_embed': 'text'})\
+                        .drop(['fSctNm', 'fEngNm', 'fileName1', 'fileName2', 'fileName3', 'publishOrg', 'colors'], axis=1)\
+                        .to_dict(orient='records')
+            
+        elif index_name == QNA_INDEX_NAME:
+            id_ = self.df['metadata'].apply(lambda x: "groro" + "_" + str(x['post_id']))
+            vector_ = self.embeddings.embed_documents(self.df['text_to_embed'].tolist())
+            metadata_ = self.df.apply(lambda x: {**x['metadata'], 'text': x['text_to_embed']}, axis=1)
+        
+        # 적재
+        insert_data = [{'id':i, 'values':v, 'metadata':m} for i, v, m in zip(id_, vector_, metadata_)]
+        self.INDEX.upsert(vectors=insert_data, namespace=f'{index_name}-{self.upsert_dt}')
+        print(f"[INFO] {index_name} | {len(insert_data)}건 적재 완료")
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="파인콘 임베딩 데이터 적재 스크립트")
+    parser.add_argument(
+        "--idx",
+        type=int,
+        required=True,
+        choices=[0, 1], 
+        help=(
+            "데이터 종류 선택\n"
+            "[0] 식물 추천용 데이터 (REC_FILE_PATH / REC_INDEX_NAME 사용)\n"
+            "[1] 식물 상담 QnA 데이터 (QNA_FILE_PATH / QNA_INDEX_NAME 사용)"
+        )
+    )
+    args = parser.parse_args()
+
+    file_path = (REC_FILE_PATH, QNA_FILE_PATH)
+    index_name = (REC_INDEX_NAME, QNA_INDEX_NAME)    
+
+    PRI = PineconeRagIngestor()
+    PRI.load_index(index_name[args.idx])
+    PRI.load_data(file_path[args.idx])
+    PRI.upsert_index(index_name[args.idx])
 
 
 if __name__ == "__main__":
-    print("데이터로드")
-    rec_data = load_data(REC_FILE_PATH)
-    qna_data = load_data(QNA_FILE_PATH)
+    main()
 
-    print("인덱스생성")
-    rec_index = create_db(REC_INDEX_NAME)
-    qna_index = create_db(QNA_INDEX_NAME)
-
-    print("추천 데이터적재")
-    insert_rec_index(rec_data)
-    
-    print("Q&A 데이터적재")
-    insert_qna_index(qna_data)
+    # 테스트
+    # PRI = PineconeRagIngestor()
+    # PRI.load_index(QNA_INDEX_NAME)
+    # response = PRI.read_index(query="스투키같은 식물은 어떻게 키워야할까요?", namespace="plant-qna-251122")
+    # response = PRI.delete_index(id_list=['groro_12976'], namespace="plant-qna-251122")
+    # print(response)


### PR DESCRIPTION
### Issues
#18

### What to do

- [x] db 관리 클래스 분리 및 CRUD 메서드 정리
- [x] 데이터 임베딩 / 적재 로직 통합 및 구조화
- [x] config 파일 정리 및 사용 모듈 리팩토링

### Description

1. PineconeManager()
  - 파인콘 인덱스 로드 및 조회, 업데이트, 삭제 메서드 정의
  - 파인콘 db 검색 테스트 및 특정 문서 접근 필요시 활용
 
2. PineconeRagIngestor()
  - 식물추천 및 상담 데이터 적재 파이프라인 개선
  - 데이터 로드, 임베딩 텍스트 전처리, 벡터적재 흐름으로 구조 통일화
  - 기존 파이썬 인터프리터 반복 구조 개선

3. main()
  - 기존 결과 기준 db 적재 테스트 확인 완료
  - 적재시 실행 방법
  ```
  python 경로/db.py --idx 0 # plant-recommend
  python 경로/db.py --idx 1 # plant-qna
  ```

4. 인덱스 추가시  
  - cofig 인덱스네임, 데이터경로 추가
  - db의 main() 내 choices 번호 추가 [0, 1, #, ...]

5. 추후 고려사항 (파인콘 db 사용법 관련 내용 discusson 등록 예정)
  - 인덱스 내 서브 namesapce 활용 전략 (검색 및 관리 효율) 
 
### References

1. code structure capture
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/b1ade78a-bdff-4352-a161-2f17eaa0ff85" />

2. code structure capture
<img width="600" height="300" alt="image" src="https://github.com/user-attachments/assets/fafec16f-58ab-4eb5-97c3-bae7b456c8a1" />

3. code structure capture
<img width="600" height="500" alt="image" src="https://github.com/user-attachments/assets/ddb480ff-dfcf-470f-8451-1b2b4f58da2d" />